### PR TITLE
Fix item normalization in take and use

### DIFF
--- a/alien_starship_adventure.py
+++ b/alien_starship_adventure.py
@@ -310,8 +310,11 @@ class Game:
         if not item:
             print("Take what?")
             return
-        
+
         room = self.rooms[self.player.current_room]
+
+        # Normalize item names to match stored identifiers
+        item = item.lower().replace(' ', '_')
         
         if item == "escape_pod":
             if self.player.current_room == "escape_pods":
@@ -347,7 +350,10 @@ class Game:
         if not item:
             print("Use what?")
             return
-        
+
+        # Normalize item names so commands like "use repair kit" work
+        item = item.lower().replace(' ', '_')
+
         if item not in self.player.inventory:
             print("You don't have that item.")
             return


### PR DESCRIPTION
## Summary
- normalize user-supplied item names in `take` and `use`

## Testing
- `python3 -m py_compile alien_starship_adventure.py`

------
https://chatgpt.com/codex/tasks/task_e_684b2b19091c8325a2210a4cfcc83c16